### PR TITLE
Fix bool type check in _verify_type_int

### DIFF
--- a/python/delta/tables.py
+++ b/python/delta/tables.py
@@ -699,7 +699,7 @@ class DeltaTable(object):
 
     @staticmethod  # type: ignore[arg-type]
     def _verify_type_int(variable: int, name: str) -> None:
-        if not isinstance(variable, int) or variable is None:
+        if variable is None or not isinstance(variable, int) or isinstance(variable, bool):
             raise ValueError("%s needs to be an int but got '%s'." % (name, type(variable)))
 
     @staticmethod

--- a/python/delta/tests/test_verify_type_int.py
+++ b/python/delta/tests/test_verify_type_int.py
@@ -1,0 +1,48 @@
+import sys
+import types
+import importlib
+import unittest
+
+class VerifyTypeIntTests(unittest.TestCase):
+    def setUp(self) -> None:
+        # Stub minimal pyspark modules required for importing delta.tables
+        pyspark = types.ModuleType('pyspark')
+        pyspark.since = lambda v: (lambda f: f)
+        sql = types.ModuleType('pyspark.sql')
+        class Column: pass
+        class DataFrame: pass
+        class SparkSession:
+            class Builder: pass
+        functions = types.ModuleType('pyspark.sql.functions')
+        sql.Column = Column
+        sql.DataFrame = DataFrame
+        sql.SparkSession = SparkSession
+        sql.functions = functions
+        sql.types = types.ModuleType('pyspark.sql.types')
+        sql.types.DataType = object
+        sql.types.StructType = object
+        sql.types.StructField = object
+        sys.modules['pyspark'] = pyspark
+        sys.modules['pyspark.sql'] = sql
+        sys.modules['pyspark.sql.functions'] = functions
+        sys.modules['pyspark.sql.types'] = sql.types
+        sys.modules['pyspark.sql.column'] = types.ModuleType('pyspark.sql.column')
+        sys.modules['pyspark.sql.column'].Column = Column
+        sys.modules['delta.exceptions'] = types.ModuleType('delta.exceptions')
+        self.DeltaTable = importlib.import_module('delta.tables').DeltaTable
+
+    def tearDown(self) -> None:
+        modules_to_remove = [m for m in sys.modules.keys() if m.startswith('pyspark') or m == 'delta.exceptions']
+        for m in modules_to_remove:
+            sys.modules.pop(m, None)
+
+    def test_bool_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            self.DeltaTable._verify_type_int(True, 'value')
+
+    def test_int_ok(self) -> None:
+        # Should not raise
+        self.DeltaTable._verify_type_int(1, 'value')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `_verify_type_int` rejects boolean values
- add regression tests using stubbed `pyspark` modules

## Testing
- `PYTHONPATH=$PWD/python python3 python/delta/tests/test_verify_type_int.py`

------
https://chatgpt.com/codex/tasks/task_e_683f71679710832fb7c57f0b0cad2c33